### PR TITLE
Remove `image_url` constraint

### DIFF
--- a/packages/app/src/components/SkuListForm/SkuListForm.tsx
+++ b/packages/app/src/components/SkuListForm/SkuListForm.tsx
@@ -28,7 +28,7 @@ export interface FormSkuListItem {
   id: string
   sku_code: string
   quantity: number
-  sku: { id: string; code: string; name: string; image_url: string }
+  sku: { id: string; code: string; name: string; image_url?: string }
 }
 
 interface Props {
@@ -187,7 +187,7 @@ export function SkuListForm({
                           id: selectedSku.id,
                           code: selectedSku.code,
                           name: selectedSku.name,
-                          image_url: selectedSku.image_url ?? ''
+                          image_url: selectedSku.image_url ?? undefined
                         }
                       }
                       selectedItems?.push(newSkuListItem)

--- a/packages/app/src/components/SkuListForm/schema.ts
+++ b/packages/app/src/components/SkuListForm/schema.ts
@@ -9,7 +9,7 @@ const formSkuListItemSchema: z.ZodType<FormSkuListItem> = z.object({
     id: z.string().min(1),
     code: z.string().min(1),
     name: z.string().min(1),
-    image_url: z.string().min(1)
+    image_url: z.string().optional()
   })
 })
 

--- a/packages/app/src/components/SkuListForm/utils.ts
+++ b/packages/app/src/components/SkuListForm/utils.ts
@@ -21,7 +21,7 @@ export function makeFormSkuListItem(skuListItem: SkuListItem): FormSkuListItem {
       id: skuListItem.sku?.id ?? '',
       code: skuListItem.sku?.code ?? '',
       name: skuListItem.sku?.name ?? '',
-      image_url: skuListItem.sku?.image_url ?? ''
+      image_url: skuListItem.sku?.image_url ?? undefined
     }
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Removed the schema constraint for SKU `image_url` to let it be empty. It was set as required by mistake.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
