### PR TITLE
Fix SKUList edit form

### DIFF
--- a/packages/app/src/components/ListItemSku.tsx
+++ b/packages/app/src/components/ListItemSku.tsx
@@ -31,7 +31,7 @@ export const ListItemSku = withSkeletonTemplate<Props>(
         className='bg-white'
       >
         <div>
-          <Text tag='div' variant='info' weight='semibold'>
+          <Text tag='div' variant='info' weight='semibold' size='small'>
             {resource.code}
           </Text>
           <Text tag='div' weight='bold'>

--- a/packages/app/src/components/SkuListForm/SkuListForm.tsx
+++ b/packages/app/src/components/SkuListForm/SkuListForm.tsx
@@ -1,5 +1,6 @@
 import { ListItemCardSkuListItem } from '#components/ListItemCardSkuListItem'
 import { useAddItemOverlay } from '#hooks/useAddItemOverlay'
+import { useSkuListItems } from '#hooks/useSkuListItems'
 import {
   Button,
   HookedForm,
@@ -27,6 +28,7 @@ export interface FormSkuListItem {
   id: string
   sku_code: string
   quantity: number
+  position: number
   sku: { id: string; code: string; name: string; image_url?: string }
 }
 
@@ -48,6 +50,7 @@ export function SkuListForm({
   apiError,
   isSubmitting
 }: Props): JSX.Element {
+  const { skuListItems } = useSkuListItems(resource?.id ?? '')
   const skuListFormMethods = useForm<SkuListFormValues>({
     defaultValues,
     resolver: zodResolver(skuListFormSchema)
@@ -71,20 +74,20 @@ export function SkuListForm({
   }, [watchedFormItems])
 
   useEffect(() => {
-    if (resource != null) {
+    if (resource != null && skuListItems != null) {
       const selectedItems = skuListFormMethods.getValues('items') ?? []
-      resource.sku_list_items?.forEach((item) => {
+      skuListItems?.forEach((item, idx) => {
         if (
           selectedItems.filter(
             (selectedItem) => selectedItem.sku_code === item.sku_code
           ).length === 0
         ) {
-          selectedItems?.push(makeFormSkuListItem(item))
+          selectedItems?.push(makeFormSkuListItem(item, idx + 1))
         }
       })
       skuListFormMethods.setValue('items', selectedItems)
     }
-  }, [resource])
+  }, [resource, skuListItems])
 
   const handleOnTabSwitch = useCallback<NonNullable<TabsProps['onTabSwitch']>>(
     (activeTab) => {
@@ -182,6 +185,7 @@ export function SkuListForm({
                         id: '',
                         sku_code: selectedSku.code,
                         quantity: 1,
+                        position: selectedItems.length + 1,
                         sku: {
                           id: selectedSku.id,
                           code: selectedSku.code,

--- a/packages/app/src/components/SkuListForm/SkuListForm.tsx
+++ b/packages/app/src/components/SkuListForm/SkuListForm.tsx
@@ -90,11 +90,9 @@ export function SkuListForm({
     (activeTab) => {
       if (activeTab === 0 && !watchedFormManual) {
         skuListFormMethods.setValue('manual', true)
-        skuListFormMethods.setValue('sku_code_regex', '')
       }
       if (activeTab === 1 && watchedFormManual) {
         skuListFormMethods.setValue('manual', false)
-        skuListFormMethods.setValue('items', [])
       }
     },
     [skuListFormMethods, watchedFormManual]

--- a/packages/app/src/components/SkuListForm/schema.ts
+++ b/packages/app/src/components/SkuListForm/schema.ts
@@ -5,6 +5,7 @@ const formSkuListItemSchema: z.ZodType<FormSkuListItem> = z.object({
   id: z.string(),
   sku_code: z.string().min(1),
   quantity: z.number().min(1),
+  position: z.number().min(1),
   sku: z.object({
     id: z.string().min(1),
     code: z.string().min(1),

--- a/packages/app/src/components/SkuListForm/utils.ts
+++ b/packages/app/src/components/SkuListForm/utils.ts
@@ -12,11 +12,15 @@ import type {
   SkuListUpdate
 } from '@commercelayer/sdk'
 
-export function makeFormSkuListItem(skuListItem: SkuListItem): FormSkuListItem {
+export function makeFormSkuListItem(
+  skuListItem: SkuListItem,
+  itemIndex: number
+): FormSkuListItem {
   return {
     id: skuListItem.id,
     quantity: skuListItem.quantity ?? 1,
     sku_code: skuListItem.sku_code ?? '',
+    position: skuListItem.position ?? itemIndex,
     sku: {
       id: skuListItem.sku?.id ?? '',
       code: skuListItem.sku?.code ?? '',

--- a/packages/app/src/hooks/useSkuListDetails.tsx
+++ b/packages/app/src/hooks/useSkuListDetails.tsx
@@ -14,20 +14,9 @@ export function useSkuListDetails(id: string): {
     isLoading,
     error,
     mutate: mutateSkuList
-  } = useCoreApi(
-    'sku_lists',
-    'retrieve',
-    [
-      id,
-      {
-        include: ['sku_list_items', 'sku_list_items.sku']
-      }
-    ],
-    {
-      isPaused: () => isMockedId(id),
-      fallbackData: makeSkuList()
-    }
-  )
+  } = useCoreApi('sku_lists', 'retrieve', isMockedId(id) ? null : [id], {
+    fallbackData: makeSkuList()
+  })
 
   return { skuList, error, isLoading, mutateSkuList }
 }

--- a/packages/app/src/hooks/useSkuListItems.tsx
+++ b/packages/app/src/hooks/useSkuListItems.tsx
@@ -1,0 +1,28 @@
+import { isMockedId } from '#mocks'
+import { useCoreApi } from '@commercelayer/app-elements'
+import type { SkuListItem } from '@commercelayer/sdk'
+
+export function useSkuListItems(id: string): {
+  skuListItems?: SkuListItem[]
+  isLoadingItems: boolean
+} {
+  const pauseRequest = isMockedId(id) || id === ''
+  const { data: skuListItems, isLoading: isLoadingItems } = useCoreApi(
+    'sku_lists',
+    'sku_list_items',
+    pauseRequest
+      ? null
+      : [
+          id,
+          {
+            include: ['sku'],
+            sort: {
+              position: 'asc'
+            },
+            pageSize: 25
+          }
+        ]
+  )
+
+  return { skuListItems, isLoadingItems }
+}

--- a/packages/app/src/pages/SkuListDetails.tsx
+++ b/packages/app/src/pages/SkuListDetails.tsx
@@ -20,6 +20,7 @@ import { Link, useLocation } from 'wouter'
 import { ListItemSkuListItem } from '#components/ListItemSkuListItem'
 import { appRoutes, type PageProps } from '#data/routes'
 import { useSkuListDetails } from '#hooks/useSkuListDetails'
+import { useSkuListItems } from '#hooks/useSkuListItems'
 import { useState } from 'react'
 
 export const SkuListDetails = (
@@ -34,6 +35,7 @@ export const SkuListDetails = (
   const skuListId = props.params?.skuListId ?? ''
 
   const { skuList, isLoading, error } = useSkuListDetails(skuListId)
+  const { skuListItems, isLoadingItems } = useSkuListItems(skuListId)
 
   const { sdkClient } = useCoreSdkProvider()
 
@@ -126,13 +128,13 @@ export const SkuListDetails = (
       scrollToTop
       gap='only-top'
     >
-      <SkeletonTemplate isLoading={isLoading}>
+      <SkeletonTemplate isLoading={isLoadingItems}>
         <Spacer top='12' bottom='4'>
           <Section title='Items'>
             {skuList.manual === true ? (
               <>
-                {skuList.sku_list_items != null
-                  ? skuList.sku_list_items.map((item) => (
+                {skuListItems != null
+                  ? skuListItems.map((item) => (
                       <ListItemSkuListItem
                         key={item.sku_code}
                         resource={item}


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- I fixed an unwanted behavior visible by clicking the SKU List form (create or update modes) tabs to change the wanted mode (automatic or manual) updating to the `manual` boolean attribute of the resource. The issue was that a tab change was wrongly set to empty either the list of selected SKU List Items or the manual mode configuration input. This is wrong and not needed because before to create or update the SKU List resource I check the value of the `manual` attribute to set either the related `sku_list_items` or the `sku_code_regex` depending on the `manual` field value. Note: If `manual` is set to `false` I already empty the `sku_code_regex` value while updating.
- I introduced a separate `useSkuListItems` hook to retrieve the related SKU List Items of a SKU List resource in a dedicated request. Thanks to this it was possibile to avoid the `include` of the `sku_list_items` in the SKU List detail request and I also sorted the items by `position` to have a fixed sort policy to represent the items list in the SKU List detail page and also during their update procedure.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
